### PR TITLE
Remove team and user mentions from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # code owners
-*  @SrimanPadmanabanCB @cbdutta
+* @cbdutta
 


### PR DESCRIPTION
## Changes

Removed team and individual user mentions from repos we don't own

### Details
- Removed @SrimanPadmanabanCB from CODEOWNERS